### PR TITLE
Fix frame update when seeking

### DIFF
--- a/packages/orengine/ts/Engine/index.ts
+++ b/packages/orengine/ts/Engine/index.ts
@@ -342,13 +342,14 @@ export class Engine extends MXP.Entity {
 
 	}
 
-	public seek( frame: number ) {
+        public seek( frame: number ) {
 
-		this._time.code = frame / 60;
+                this._time.code = frame / 60;
+                this._frame.current = frame;
 
-		this.emit( "update/frame/play", [ this._frame ] );
+                this.emit( "update/frame/play", [ this._frame ] );
 
-	}
+        }
 
 	/*-------------------------------
 		CompileShaders


### PR DESCRIPTION
## Summary
- update frame state immediately when Engine.seek() is called

## Testing
- `npx tsc --noEmit` *(fails: Output file has not been built)*

------
https://chatgpt.com/codex/tasks/task_e_683ff67e533c832aa44505219f590b54