### PR TITLE
Fix tests to match current API

### DIFF
--- a/tests/entity.test.ts
+++ b/tests/entity.test.ts
@@ -15,21 +15,21 @@ describe('Entity class', () => {
     expect(parent.children).not.toContain(child);
   });
 
-  it('getEntityByName finds nested children', () => {
+  it('findEntityByName finds nested children', () => {
     const root = new Entity({ name: 'root' });
     const a = new Entity({ name: 'a' });
     const b = new Entity({ name: 'b' });
     root.add(a);
     a.add(b);
 
-    expect(root.getEntityByName('b')).toBe(b);
-    expect(root.getEntityByName('unknown')).toBeUndefined();
+    expect(root.findEntityByName('b')).toBe(b);
+    expect(root.findEntityByName('unknown')).toBeUndefined();
   });
 
-  it('getPath returns hierarchy path', () => {
+  it('getScenePath returns hierarchy path', () => {
     const root = new Entity({ name: 'root' });
     const child = new Entity({ name: 'child' });
     root.add(child);
-    expect(child.getPath()).toBe('/root/child');
+    expect(child.getScenePath()).toBe('/root/child');
   });
 });

--- a/tests/material.test.ts
+++ b/tests/material.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
 
-vi.mock('../packages/maxpower/Component/Material/shaders/basic.fs', () => ({ default: '' }));
-vi.mock('../packages/maxpower/Component/Material/shaders/basic.vs', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Material/shaders/basic.fs', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Material/shaders/basic.vs', () => ({ default: '' }));
 
-import { Material } from '../packages/maxpower/Component/Material';
+import { Material } from '../packages/maxpower/Material';
 
 describe('Material class', () => {
   it('initializes with default flags', () => {
@@ -13,21 +13,18 @@ describe('Material class', () => {
     expect(m.visibilityFlag.forward).toBe(false);
   });
 
-  it('setPropertyValues updates values and resets program cache', () => {
+  it('updates values and resets program cache with requestUpdate', () => {
     const m = new Material();
     (m as any).programCache.example = {};
 
-    m.setPropertyValues({
-      name: 'foo',
-      forward: true,
-      deferred: false,
-      shadowMap: false,
-      ui: false,
-      useLight: false,
-      depthTest: false,
-      cullFace: false,
-      drawType: 'LINES',
-    });
+    m.name = 'foo';
+    m.visibilityFlag.forward = true;
+    m.visibilityFlag.deferred = false;
+    m.useLight = false;
+    m.depthTest = false;
+    m.cullFace = false;
+    m.drawType = 'LINES';
+    m.requestUpdate();
 
     expect(m.name).toBe('foo');
     expect(m.visibilityFlag.forward).toBe(true);


### PR DESCRIPTION
## Summary
- update Material test to use new API
- update Entity tests for renamed methods
- use submodule glpower to satisfy path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68401b280cd4832a8565e1598bbd5123