### PR TITLE
Update README with init instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ OREngine (オーアールエンジン) は WebGL 製の軽量 3D エンジンで
 
 ### 1. サブモジュールと依存パッケージの取得
 
+`packages/glpower` は git submodule として提供されています。このサブモジュールを含む依存パッケージ一式を取得するため、以下のコマンドを実行します。
+
 ```bash
 npm run init
 ```
@@ -42,8 +44,18 @@ npm run dev
 
 ## ビルド
 
+> **重要:** ビルドやテストを行う前に一度 `npm run init` を実行してサブモジュール（`packages/glpower` など）を初期化してください。
+
 ```bash
 npm run build
+```
+
+## テスト
+
+ビルドと同様に、事前に `npm run init` を実行してサブモジュールを初期化しておく必要があります。
+
+```bash
+npm run test
 ```
 
 ## ドキュメント


### PR DESCRIPTION
## Summary
- clarify that `packages/glpower` is provided via git submodule
- add reminder to run `npm run init` before building or testing
- document how to run tests

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68402707a38c832a98e9ac961a740170