### PR TITLE
Add coverage for misc utilities

### DIFF
--- a/tests/entity-traverse.test.ts
+++ b/tests/entity-traverse.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Entity } from '../packages/maxpower/Entity';
+import { Component } from '../packages/maxpower/Component';
+
+class DummyComponent extends Component {}
+
+describe('Entity dispose and traversal', () => {
+  it('dispose removes from parent and disposes components', () => {
+    const parent = new Entity({ name: 'parent' });
+    const child = new Entity({ name: 'child' });
+    parent.add(child);
+    const comp = child.addComponent(DummyComponent);
+    const spy = vi.spyOn(comp, 'dispose');
+
+    child.dispose();
+    expect(parent.children).not.toContain(child);
+    expect(spy).toHaveBeenCalled();
+    expect(child.components.size).toBe(0);
+  });
+
+  it('traverse visits all descendants', () => {
+    const root = new Entity({ name: 'root' });
+    const a = new Entity({ name: 'a' });
+    const b = new Entity({ name: 'b' });
+    root.add(a);
+    a.add(b);
+    const names: string[] = [];
+    root.traverse(e => names.push(e.name));
+    expect(names).toEqual(['root', 'a', 'b']);
+  });
+
+  it('noticeEventChilds and noticeEventParent propagate events', () => {
+    const root = new Entity();
+    const child = new Entity();
+    root.add(child);
+
+    const spyChild = vi.fn();
+    const spyParent = vi.fn();
+    child.on('ping', spyChild);
+    root.on('pong', spyParent);
+
+    root.noticeEventChilds('ping', ['hello']);
+    expect(spyChild).toHaveBeenCalledWith('hello');
+
+    child.noticeEventParent('pong', [42]);
+    expect(spyParent).toHaveBeenCalledWith(42);
+  });
+});

--- a/tests/serializable-extra.test.ts
+++ b/tests/serializable-extra.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { Serializable } from '../packages/maxpower/Serializable';
+
+function createSimple() {
+  const s = new Serializable();
+  let val = 0;
+  s.field('foo', () => val, v => { val = v; });
+  return { s, get val() { return val; }, set val(v: number) { val = v; } };
+}
+
+describe('Serializable deserialize and field helpers', () => {
+  it('updates fields via deserialize', () => {
+    const { s } = createSimple();
+    s.deserialize({ foo: 3 });
+    expect(s.getField('foo')).toBe(3);
+  });
+
+  it('setField and getField mirror stored value', () => {
+    const { s } = createSimple();
+    s.setField('foo', 5);
+    expect(s.getField('foo')).toBe(5);
+  });
+});

--- a/tests/shader-parser.test.ts
+++ b/tests/shader-parser.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderModules/common.module.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderModules/light.module.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderModules/noiseCyclic.module.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderModules/noiseSimplex.module.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderModules/noiseValue.module.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderModules/pmrem.module.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderModules/random.module.glsl', () => ({ default: 'float random(vec2 p){return 0.;}' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderModules/raymarch_normal.module.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderModules/rotate.module.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderModules/sdf.module.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderParts/frag_h.part.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderParts/frag_in.part.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderParts/frag_out.part.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderParts/lighting_env.part.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderParts/lighting_forwardIn.part.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderParts/lighting_light.part.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderParts/raymarch_h.part.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderParts/raymarch_out_obj.part.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderParts/raymarch_ray_object.part.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderParts/raymarch_ray_world.part.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderParts/uniform_time.part.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderParts/vert_h.part.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderParts/vert_in.part.glsl', () => ({ default: '' }));
+vi.mock('../packages/maxpower/Utils/ShaderParser/shaderParts/vert_out.part.glsl', () => ({ default: '' }));
+
+import { shaderInsertDefines, shaderInclude } from '../packages/maxpower/Utils/ShaderParser';
+
+describe('ShaderParser helpers', () => {
+  it('shaderInsertDefines prepends defines', () => {
+    const shader = 'void main(){}';
+    const res = shaderInsertDefines(shader, { FOO: 1, BAR: 'true' });
+    expect(res.startsWith('#define FOO 1\n#define BAR true\n')).toBe(true);
+    expect(res.endsWith(shader)).toBe(true);
+  });
+
+  it('shaderInclude replaces include directives', () => {
+    const shader = '#include <random>'; // random.module.glsl exports function random
+    const res = shaderInclude(shader);
+    expect(res).toContain('float random');
+    expect(res).not.toMatch(/#include/);
+  });
+});

--- a/tests/uniforms.test.ts
+++ b/tests/uniforms.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { UniformsUtils } from '../packages/maxpower/Utils/Uniforms';
+
+describe('UniformsUtils', () => {
+  it('assign merges uniforms into target', () => {
+    const target: any = { a: 1 };
+    const res = UniformsUtils.assign(target, { b: 2 }, undefined, { c: 3 });
+    expect(res).toEqual({ a: 1, b: 2, c: 3 });
+    expect(res).toBe(target);
+  });
+
+  it('merge combines uniforms into new object', () => {
+    const u1: any = { a: 1 };
+    const merged = UniformsUtils.merge(u1, { b: 2 });
+    expect(merged).toEqual({ a: 1, b: 2 });
+    expect(merged).not.toBe(u1);
+  });
+});


### PR DESCRIPTION
## Summary
- add Serializable helper tests
- add UniformsUtils tests for assign/merge
- test ShaderParser helper functions
- test entity dispose and traversal behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68402701d3e0832aadf6aee3c5af0525