### PR TITLE
Fix SerializableFieldOpt definition

### DIFF
--- a/packages/maxpower/Serializable/index.ts
+++ b/packages/maxpower/Serializable/index.ts
@@ -19,11 +19,11 @@ interface SerializeFieldFormatArray {
 
 export type SerializableFieldFormat = SerializeFieldFormatVector | SerializeFieldFormatSelect | SerializeFieldFormatArray
 
-export type SerializableFieldOpt<> = {
-	isFolder?: boolean,
-	noExport?: boolean,
-	hidden?: boolean | ( ( value: SerializeFieldValue ) => boolean ),
-	format?: SerializableFieldFormat,
+export type SerializableFieldOpt = {
+        isFolder?: boolean,
+        noExport?: boolean,
+        hidden?: boolean | ( ( value: SerializeFieldValue ) => boolean ),
+        format?: SerializableFieldFormat,
 } & ValueOpt
 
 export type SerializeFieldPrimitive = number | string | boolean | null | undefined | ( () => void );


### PR DESCRIPTION
## Summary
- remove stray generic angle brackets from SerializableFieldOpt type definition

## Testing
- `npm test` *(fails: Failed to load url /workspace/OREngine/packages/glpower/packages/glpower/src)*

------
https://chatgpt.com/codex/tasks/task_e_6840274aa3e0832abfa636e3aa7c1fbe