### PR TITLE
Refactor timeline hook

### DIFF
--- a/packages/orengine/tsx/components/Panels/Timeline/Context/TimelineContext/index.tsx
+++ b/packages/orengine/tsx/components/Panels/Timeline/Context/TimelineContext/index.tsx
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+import { useTimelineContext } from "../../Hooks/useTimelineContext";
+
+export const TimelineContext = createContext<ReturnType<typeof useTimelineContext> | null>( null );

--- a/packages/orengine/tsx/components/Panels/Timeline/Hooks/useTimelineContext/index.tsx
+++ b/packages/orengine/tsx/components/Panels/Timeline/Hooks/useTimelineContext/index.tsx
@@ -1,11 +1,9 @@
-import { useState, useCallback, useEffect, createContext, useRef } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 
 import { FramePlay } from "../../../../../../ts/Engine";
 import { useOREditor } from "../../../../../../tsx/hooks/useOREditor";
 
-export const TimelineContext = createContext<HooksContext<typeof useTimeline>>( {} );
-
-export const useTimeline = () => {
+export const useTimelineContext = () => {
 
 	const { editor: glEditor } = useOREditor();
 

--- a/packages/orengine/tsx/components/Panels/Timeline/TimelineCanvas/index.tsx
+++ b/packages/orengine/tsx/components/Panels/Timeline/TimelineCanvas/index.tsx
@@ -1,7 +1,7 @@
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useSerializableField } from '../../../../hooks/useSerializableProps';
-import { TimelineContext } from '../hooks/useTimeline';
+import { useTimeline } from '../../../../hooks/useTimeline';
 
 import style from './index.module.scss';
 import { TimelineCanvasRenderer } from './TimelineCanvasRenderer';
@@ -9,7 +9,7 @@ import { TimelineCanvasRenderer } from './TimelineCanvasRenderer';
 
 export const TimelineCanvas = () => {
 
-	const { viewPort, viewPortScale, musicBuffer, musicBufferVersion, glEditor } = useContext( TimelineContext );
+  const { viewPort, viewPortScale, musicBuffer, musicBufferVersion, glEditor } = useTimeline();
 
 	const [ renderer, setRenderer ] = useState<TimelineCanvasRenderer>();
 

--- a/packages/orengine/tsx/components/Panels/Timeline/TimelineControls/index.tsx
+++ b/packages/orengine/tsx/components/Panels/Timeline/TimelineControls/index.tsx
@@ -1,12 +1,12 @@
-import React, { useCallback, useContext, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 
-import { TimelineContext } from '../hooks/useTimeline';
+import { useTimeline } from '../../../../hooks/useTimeline';
 
 import style from './index.module.scss';
 
 export const TimelineControls: React.FC<{children?: React.ReactNode}> = ( props ) => {
 
-	const { viewPort, setCurrentFrame: setFrame, getFrameViewPort, zoom, scroll, setViewPortCenter } = useContext( TimelineContext );
+  const { viewPort, setCurrentFrame: setFrame, getFrameViewPort, zoom, scroll, setViewPortCenter } = useTimeline();
 
 	const viewPortRef = useRef( [ 0, 0, 0, 0 ] );
 	const viewPortRangeRef = useRef( [ 0, 0 ] );

--- a/packages/orengine/tsx/components/Panels/Timeline/TimelineCursor/index.tsx
+++ b/packages/orengine/tsx/components/Panels/Timeline/TimelineCursor/index.tsx
@@ -1,12 +1,10 @@
-import { useContext } from 'react';
-
-import { TimelineContext } from '../hooks/useTimeline';
+import { useTimeline } from '../../../../hooks/useTimeline';
 
 import style from './index.module.scss';
 
 export const TimelineCursor = () => {
 
-	const { viewPort, framePlay } = useContext( TimelineContext );
+        const { viewPort, framePlay } = useTimeline();
 
 	if ( ! viewPort || ! framePlay ) return null;
 

--- a/packages/orengine/tsx/components/Panels/Timeline/TimelineLoop/index.tsx
+++ b/packages/orengine/tsx/components/Panels/Timeline/TimelineLoop/index.tsx
@@ -1,8 +1,8 @@
-import { useContext, useRef } from 'react';
+import { useRef } from 'react';
 
 import { useSerializableField } from '../../../../hooks/useSerializableProps';
 import { useWatchSerializable } from '../../../../hooks/useWatchSerializable';
-import { TimelineContext } from '../hooks/useTimeline';
+import { useTimeline } from '../../../../hooks/useTimeline';
 
 import style from './index.module.scss';
 import { TimelineLoopCursor } from './TimelineLoopCursor';
@@ -10,7 +10,7 @@ import { TimelineLoopCursor } from './TimelineLoopCursor';
 
 export const TimelineLoop = () => {
 
-	const { viewPort, framePlay, glEditor } = useContext( TimelineContext );
+        const { viewPort, framePlay, glEditor } = useTimeline();
 
 	const elmRef = useRef<HTMLDivElement>( null );
 

--- a/packages/orengine/tsx/components/Panels/Timeline/TimelineScale/index.tsx
+++ b/packages/orengine/tsx/components/Panels/Timeline/TimelineScale/index.tsx
@@ -1,7 +1,6 @@
-import { useContext } from 'react';
+import { useTimeline } from '../../../../hooks/useTimeline';
 
 import { useSerializableField } from '../../../../hooks/useSerializableProps';
-import { TimelineContext } from '../hooks/useTimeline';
 
 import style from './index.module.scss';
 
@@ -17,7 +16,7 @@ const formatTime = ( sec: number ) => {
 
 export const TimelineScale = () => {
 
-	const { glEditor, viewPort, viewPortScale } = useContext( TimelineContext );
+        const { glEditor, viewPort, viewPortScale } = useTimeline();
 
 	const [ fps, setFps ] = useSerializableField<number>( glEditor?.engine, "timeline/fps" );
 

--- a/packages/orengine/tsx/components/Panels/Timeline/TimelineSetting/index.tsx
+++ b/packages/orengine/tsx/components/Panels/Timeline/TimelineSetting/index.tsx
@@ -1,18 +1,18 @@
 import * as MXP from 'maxpower';
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
 
 import { useSerializableField } from '../../../../hooks/useSerializableProps';
 import { Label } from '../../../Label';
 import { Panel } from '../../../Panel';
 import { Value } from '../../../Value';
-import { TimelineContext } from '../hooks/useTimeline';
+import { useTimeline } from '../../../../hooks/useTimeline';
 
 import style from './index.module.scss';
 
 
 export const TimelineSetting = () => {
 
-	const { framePlay, glEditor } = useContext( TimelineContext );
+  const { framePlay, glEditor } = useTimeline();
 
 	const onChange = useCallback( ( value: MXP.SerializeFieldValue, setter: ( ( value: any ) => void ) | undefined ) => {
 

--- a/packages/orengine/tsx/components/Panels/Timeline/index.tsx
+++ b/packages/orengine/tsx/components/Panels/Timeline/index.tsx
@@ -1,4 +1,5 @@
-import { TimelineContext, useTimeline } from './hooks/useTimeline';
+import { TimelineContext } from './Context/TimelineContext';
+import { useTimelineContext } from './Hooks/useTimelineContext';
 import style from './index.module.scss';
 import { TimelineCanvas } from './TimelineCanvas';
 import { TimelineControls } from './TimelineControls';
@@ -10,7 +11,7 @@ import { TimelineSetting } from './TimelineSetting';
 
 export const Timeline = () => {
 
-	const timelineContext = useTimeline();
+  const timelineContext = useTimelineContext();
 
 	return <TimelineContext.Provider value={timelineContext}>
 		<div className={style.timeline}>

--- a/packages/orengine/tsx/hooks/useTimeline/index.tsx
+++ b/packages/orengine/tsx/hooks/useTimeline/index.tsx
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+
+import { TimelineContext } from "../../components/Panels/Timeline/Context/TimelineContext";
+
+export const useTimeline = () => {
+        const context = useContext( TimelineContext );
+        if ( context === null ) {
+                throw new Error( "useTimeline must be used within a TimelineProvider" );
+        }
+        return context;
+};


### PR DESCRIPTION
## Summary
- refactor Timeline hook into proper context-style design
- add TimelineContext and new hooks
- update timeline components to use new context

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_68402e1711c0832ab15f365cf6cc772b