### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,80 @@
+name: deploy-pages
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - develop
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+      - name: Install dependencies
+        run: npm ci
+      - name: Install shader-minifier
+        run: npm install shader-minifier
+      - name: Setup shader-minifier PATH
+        run: echo "$(pwd)/node_modules/shader-minifier/binary" >> $GITHUB_PATH
+      - name: Determine deploy path
+        id: vars
+        run: |
+          REPO="/${{ github.event.repository.name }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "BASE=${REPO}/pr-${{ github.event.pull_request.number }}/" >> "$GITHUB_OUTPUT"
+            echo "DIR=pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref_name }}" = "develop" ]; then
+            echo "BASE=${REPO}/develop/" >> "$GITHUB_OUTPUT"
+            echo "DIR=develop" >> "$GITHUB_OUTPUT"
+          else
+            echo "BASE=${REPO}/" >> "$GITHUB_OUTPUT"
+            echo "DIR=" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Build demo
+        run: npm run prebuild
+        env:
+          BASE_PATH: ${{ steps.vars.outputs.BASE }}
+          SKIP_SHADER_MINIFIER: 'true'
+      - name: Prepare Pages artifact
+        run: |
+          if [ -z "${{ steps.vars.outputs.DIR }}" ]; then
+            mkdir -p public
+            cp -r dist/* public/
+          else
+            mkdir -p public/${{ steps.vars.outputs.DIR }}
+            cp -r dist/* public/${{ steps.vars.outputs.DIR }}/
+          fi
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_name == 'develop' && 'github-pages-develop' || 'github-pages' }}
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          preview: ${{ github.event_name == 'pull_request' }}
+

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ npm run dev
 npm run build
 ```
 
+## デモ公開 (GitHub Pages)
+
+`main` または `master` へ push すると `https://<user>.github.io/<repo>/` にデプロイされます。`develop` ブランチは `https://<user>.github.io/<repo>/develop/`、プルリクエストは `https://<user>.github.io/<repo>/pr-<番号>/` にそれぞれ配置されます。ワークフローの設定は `.github/workflows/pages.yml` にあります。
+
+デモ用のビルドでは ShaderMinifier をスキップしているため、`SKIP_SHADER_MINIFIER=true` が環境変数として渡されます。将来的に Storybook を追加した場合は `public/storybook` 以下に成果物を配置することで同じ仕組みでデプロイできます。
+
 ## テスト
 
 ビルドと同様に、事前に `npm run init` を実行してサブモジュールを初期化しておく必要があります。

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "init": "git submodule init && git submodule update && npm install",
     "dev": "vite",
-    "prebuild": "NODE_ENV=production IS_PREVIEW=true vite build",
+    "prebuild": "NODE_ENV=production IS_PREVIEW=true SKIP_SHADER_MINIFIER=true vite build",
     "preview": "vite preview",
     "build": "vite build --config vite-player.config.ts && node compeko.js ./dist/build/index.js ./dist/build/index.html",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/plugins/ShaderMinifierLoader/index.ts
+++ b/plugins/ShaderMinifierLoader/index.ts
@@ -23,7 +23,9 @@ export const ShaderMinifierLoader = (): Plugin => {
 		},
 	);
 
-	const filter = createFilter( options.include, options.exclude );
+        const filter = createFilter( options.include, options.exclude );
+
+       const skip = process.env.SKIP_SHADER_MINIFIER === 'true';
 
 	return {
 		name: 'shaderMinifier',
@@ -109,9 +111,9 @@ export const ShaderMinifierLoader = (): Plugin => {
 
 			}
 
-			// through
+                        // through
 
-			if ( false ) {
+                        if ( skip ) {
 
 				return {
 					code: `export default ${JSON.stringify( code )};`,

--- a/vite-player.config.ts
+++ b/vite-player.config.ts
@@ -9,11 +9,12 @@ import { nameCache, MangledJsonLoader, SaveNameCache } from './plugins/MangleMan
 import { ShaderMinifierLoader } from './plugins/ShaderMinifierLoader';
 
 
-const basePath = ``;
+const basePath = process.env.BASE_PATH ?? "";
 
 // player.jsonからreservedに追加するプロパティ名を抽出
 export default defineConfig( {
-	root: 'src',
+        root: 'src',
+        base: basePath,
 	server: {
 		port: 3000,
 		host: "0.0.0.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,11 +8,12 @@ import { ResourceManager } from './plugins/ResourceManager';
 import { ShaderMinifierLoader } from "./plugins/ShaderMinifierLoader";
 
 
-const basePath = ``;
+const basePath = process.env.BASE_PATH ?? "";
 
 // https://vitejs.dev/config/
 export default defineConfig( {
-	root: 'src',
+        root: 'src',
+        base: basePath,
 	server: {
 		port: 3000,
 		host: "0.0.0.0",


### PR DESCRIPTION
## Summary
- deploy demo using GitHub Pages via new `pages.yml`
- document the automated deployment in README
- fix asset base path so artifacts deploy under `<repo>/develop/` and `pr-<number>`

## Testing
- `npm run init`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840f0ccbc6c832ab2a42485ea1f570d