### PR TITLE
Fix permissions for cleanup workflow

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -11,6 +11,8 @@ on:
 
 permissions:
   contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   cleanup:
@@ -45,14 +47,14 @@ jobs:
             const prNumber = context.payload.pull_request.number;
             const merged = context.payload.pull_request.merged;
             const action = merged ? 'merged' : 'closed';
-            
+
             const body = `🧹 **Preview cleaned up!**
-            
+
             The preview for this PR has been removed since it was ${action}.`;
-            
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
               body: body
-            }); 
+            });


### PR DESCRIPTION
## Summary
- allow cleanup workflow to comment on PRs
- tidy whitespace

## Testing
- `npm test` *(fails: Failed to load url /workspace/OREngine/packages/glpower/packages/glpower/src)*

------
https://chatgpt.com/codex/tasks/task_e_6842408533ec832a8bf0ec826e22f3fb