### PR TITLE
Add Storybook stories for more components

### DIFF
--- a/packages/orengine/stories/Block.stories.tsx
+++ b/packages/orengine/stories/Block.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Block } from '../tsx/components/Block';
+
+export const Basic = () => (
+  <Block label="Example Block">
+    <div style={{ padding: '8px', background: '#eee' }}>Content</div>
+  </Block>
+);
+
+export const Accordion = () => (
+  <Block label="Accordion Block" accordion>
+    <div style={{ padding: '8px' }}>Hidden Content</div>
+  </Block>
+);
+
+export default {
+  title: 'orengine/Block',
+  component: Block,
+};

--- a/packages/orengine/stories/InputBoolean.stories.tsx
+++ b/packages/orengine/stories/InputBoolean.stories.tsx
@@ -1,0 +1,12 @@
+import React, { useState } from 'react';
+import { InputBoolean } from '../tsx/components/Input/InputCheckBox';
+
+export const Basic = () => {
+  const [checked, setChecked] = useState(true);
+  return <InputBoolean checked={checked} onChange={setChecked} />;
+};
+
+export default {
+  title: 'orengine/InputBoolean',
+  component: InputBoolean,
+};

--- a/packages/orengine/stories/InputGroup.stories.tsx
+++ b/packages/orengine/stories/InputGroup.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { InputGroup } from '../tsx/components/InputGroup';
+
+export const Basic = () => (
+  <InputGroup
+    title="User Info"
+    initialValues={{ name: '', age: 20, active: true }}
+    onSubmit={values => alert(JSON.stringify(values))}
+  />
+);
+
+export default {
+  title: 'orengine/InputGroup',
+  component: InputGroup,
+};

--- a/packages/orengine/stories/InputNumber.stories.tsx
+++ b/packages/orengine/stories/InputNumber.stories.tsx
@@ -1,0 +1,12 @@
+import React, { useState } from 'react';
+import { InputNumber } from '../tsx/components/Input/InputNumber';
+
+export const Basic = () => {
+  const [value, setValue] = useState(0);
+  return <InputNumber value={value} onChange={setValue} />;
+};
+
+export default {
+  title: 'orengine/InputNumber',
+  component: InputNumber,
+};

--- a/packages/orengine/stories/InputSelect.stories.tsx
+++ b/packages/orengine/stories/InputSelect.stories.tsx
@@ -1,0 +1,18 @@
+import React, { useState } from 'react';
+import { InputSelect } from '../tsx/components/Input/InputSelect';
+
+export const Basic = () => {
+  const [value, setValue] = useState('A');
+  return (
+    <InputSelect
+      value={value}
+      selectList={['A', 'B', 'C']}
+      onChange={setValue}
+    />
+  );
+};
+
+export default {
+  title: 'orengine/InputSelect',
+  component: InputSelect,
+};

--- a/packages/orengine/stories/InputText.stories.tsx
+++ b/packages/orengine/stories/InputText.stories.tsx
@@ -1,0 +1,13 @@
+import React, { useState } from 'react';
+import { InputText } from '../tsx/components/Input/InputText';
+
+export const Basic = () => {
+  const [value, setValue] = useState('Hello');
+  return <InputText value={value} onChange={setValue} />;
+};
+
+export default {
+  title: 'orengine/InputText',
+  component: InputText,
+};
+

--- a/packages/orengine/stories/Label.stories.tsx
+++ b/packages/orengine/stories/Label.stories.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Label } from '../tsx/components/Label';
+
+export const Basic = () => (
+  <Label title="Label title">Sample</Label>
+);
+
+export default {
+  title: 'orengine/Label',
+  component: Label,
+};
+

--- a/packages/orengine/stories/Vector.stories.tsx
+++ b/packages/orengine/stories/Vector.stories.tsx
@@ -1,0 +1,12 @@
+import React, { useState } from 'react';
+import { Vector } from '../tsx/components/Vector';
+
+export const Basic = () => {
+  const [value, setValue] = useState([0, 0, 0]);
+  return <Vector value={value} onChange={setValue} />;
+};
+
+export default {
+  title: 'orengine/Vector',
+  component: Vector,
+};


### PR DESCRIPTION
## Summary
- add stories for InputBoolean, InputNumber, and InputSelect
- add Block, InputGroup, and Vector stories

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run test` *(fails: Failed to load url /workspace/OREngine/packages/glpower/packages/glpower/src)*

------
https://chatgpt.com/codex/tasks/task_e_6842cfef5e34832aa16139d5677a057c