### PR TITLE
利用側リポジトリのセットアップスクリプトを追加しREADMEの手順を簡素化する

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,88 +13,49 @@ OREngine (オーアールエンジン) は 64KB Intro 制作のための 3D エ�
 
 OREngine は npm パッケージとしては公開しておらず、git submodule として組み込んで利用します。作品リポジトリ側にはプロジェクトデータ（シーン・コンポーネント）と起動スクリプトだけを置き、開発サーバー・エディタ・ビルドはすべて submodule 側の `orengine/host` が提供します。
 
-### 1. submodule の追加とセットアップ
+### 1. セットアップ
 
-Node.js 24 系で動作します。
+Node.js 24 系で動作します。submodule を追加してセットアップスクリプトを実行するだけです。
 
 ```bash
 git submodule add https://github.com/ukonpower/OREngine.git orengine
 (cd orengine && npm install)
-npm install -D tsx
+npx tsx orengine/scripts/init.ts
+npm install
 ```
 
-依存パッケージはすべて OREngine 側が持っているため、利用側リポジトリに必要なのは実行用の `tsx` だけです。
+`init.ts` が利用側リポジトリに以下を生成します（既存のファイルは上書きしません）。
 
-### 2. プロジェクトディレクトリの作成
+- `project/` — プロジェクトデータ（`scene.json` / `editor.json` / `Resources/` / `public/`）
+- `tsconfig.json` — パスエイリアスを submodule に向けた TypeScript 設定
+- `package.json` — `dev` / `player:build` / `editor:build` の scripts と、実行に必要な `tsx`（依存パッケージはすべて OREngine 側が持ちます）
 
-テンプレートをコピーして始めます。
+### 2. 開発
 
 ```bash
-cp -r orengine/host/template/project ./project
+npm run dev
 ```
 
-```
-project/
-├── scene.json    # シーン定義
-├── editor.json   # エディタ設定
-├── Resources/    # コンポーネント・シェーダー・テクスチャ等
-└── public/       # 静的ファイル
-```
+エディタ付き開発サーバーが起動します。`project/scene.json` やコンポーネントのファイルを直接編集すると、変更検知でブラウザが自動リロードされます。
 
-`Resources/Components/<グループ>/<名前>/index.ts` に `MXP.Component` を継承したクラスを export すると、コンポーネントとして自動で認識されます。
+`project/Resources/Components/<グループ>/<名前>/index.ts` に `MXP.Component` を継承したクラスを export すると、コンポーネントとして自動で認識されます。
 
-### 3. 起動スクリプト
+レンダラーは環境変数で切り替えられます（デフォルトは webgl）。
 
-`orengine/host` の API をプロジェクトディレクトリに向けて呼ぶだけです。tsx 経由で実行します。
-
-```js
-// scripts/run.mjs — 実行: npx tsx scripts/run.mjs
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const repoRoot = path.resolve( fileURLToPath( import.meta.url ), '../..' );
-const projectDir = path.join( repoRoot, 'project' );
-
-const { runDev } = await import( '../orengine/host/index.ts' );
-
-await runDev( { projectDir } );
+```bash
+ORENGINE_RENDERER=webgpu npm run dev
 ```
 
-- `runDev( { projectDir } )` — エディタ付き開発サーバーを起動。`scene.json` やコンポーネントのファイルを直接編集すると、変更検知でブラウザが自動リロードされます
-- `runBuildPlayer( { projectDir } )` — 64KB 配布形式の自己解凍 HTML を `dist/player/out.html` に出力
-- `runBuildStatic( { projectDir } )` — エディタ込み HTML を `dist/static/` に出力
+### 3. ビルド
 
-オプションで `renderer: 'webgl' | 'webgpu' | 'headless'`（デフォルトは webgl）、`port` / `apiPort` / `basePath` / `https` を指定できます。
-
-### 4. TypeScript 設定
-
-コンポーネントの型チェックには、利用側リポジトリの `tsconfig.json` でパスエイリアスを submodule に向けます。
-
-```jsonc
-{
-	"compilerOptions": {
-		"moduleResolution": "bundler",
-		"baseUrl": ".",
-		"paths": {
-			"basepower": [ "./orengine/packages/basepower" ],
-			"mathpower": [ "./orengine/packages/mathpower" ],
-			"glpower": [ "./orengine/packages/glpower" ],
-			"maxpower": [ "./orengine/packages/maxpower/webgl" ],
-			"maxpower/webgpu": [ "./orengine/packages/maxpower/webgpu" ],
-			"orengine": [ "./orengine/packages/orengine/index.ts" ],
-			"orengine/*": [ "./orengine/packages/orengine/*" ],
-			"@or-renderer": [ "./orengine/packages/maxpower/webgl/index.ts" ],
-			"@or-scene": [ "./project/scene.json" ],
-			"@or-editor": [ "./project/editor.json" ],
-			"@or-resources/*": [ "./project/Resources/*" ]
-		}
-	}
-}
+```bash
+npm run player:build # 64KB 配布形式の自己解凍 HTML → project/dist/player/out.html
+npm run editor:build # エディタ込み HTML → project/dist/static/
 ```
 
-tsc も submodule 側のもの（`./orengine/node_modules/.bin/tsc`）を流用できます。
+生成された scripts は `orengine/scripts/run.ts` を呼んでいるだけです。プログラムから制御したい場合は `orengine/host` の `runDev` / `runBuildPlayer` / `runBuildStatic` を import して使えます（`renderer` / `port` / `apiPort` / `basePath` / `https` を指定可能）。
 
-### 5. Shader Minifier の準備（player ビルドに必要）
+### 4. Shader Minifier の準備（player ビルドに必要）
 
 player ビルドのシェーダー圧縮に [Shader Minifier](https://github.com/laurentlb/Shader_Minifier) を使用します。macOS / Linux はセットアップスクリプトで Shader Minifier と Mono を導入できます（`~/Documents/application/shader_minifier/` に配置されます）。
 
@@ -105,7 +66,7 @@ player ビルドのシェーダー圧縮に [Shader Minifier](https://github.com
 Windows は shader_minifier.exe を取得し、Path を設定してください。配置場所を変えたい場合は、環境変数 `ORENGINE_SHADER_MINIFIER` に実行コマンド全体を指定します。
 
 ```bash
-ORENGINE_SHADER_MINIFIER="mono /path/to/shader_minifier.exe" npx tsx scripts/run.mjs
+ORENGINE_SHADER_MINIFIER="mono /path/to/shader_minifier.exe" npm run player:build
 ```
 
 Shader Minifier が見つからない環境では minify をスキップして生の GLSL にフォールバックします（警告が出ます。packed サイズは本番相当になりません）。

--- a/host/runner.ts
+++ b/host/runner.ts
@@ -1,3 +1,7 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { build, createServer, InlineConfig } from 'vite';
 
 import { startOrengineServer, OrengineServerHandle } from './server/factory';
@@ -5,6 +9,8 @@ import { createDevConfig, createPlayerConfig, createStaticConfig } from './vite/
 
 import type { RendererName } from './vite/configs';
 import type { ViteDevServer } from 'vite';
+
+const orengineRoot = path.resolve( fileURLToPath( import.meta.url ), '../..' );
 
 
 export interface HostRunOptions {
@@ -62,9 +68,16 @@ export const runDev = async ( opts: HostRunOptions ): Promise<DevHandle> => {
 
 };
 
+// playerバンドルをビルドし、compeko で自己解凍 html（64k配布形式）にパックする
 export const runBuildPlayer = async ( opts: HostRunOptions ) => {
 
-	return build( createPlayerConfig( opts ) as InlineConfig );
+	const result = await build( createPlayerConfig( opts ) as InlineConfig );
+
+	const playerJs = path.join( opts.projectDir, 'dist/player/index.js' );
+	const packedHtml = path.join( opts.projectDir, 'dist/player/out.html' );
+	execFileSync( 'node', [ path.join( orengineRoot, 'tools/compeko.js' ), playerJs, packedHtml ], { stdio: 'inherit' } );
+
+	return result;
 
 };
 

--- a/host/template/project/Resources/Components/Samples/SampleCube/index.ts
+++ b/host/template/project/Resources/Components/Samples/SampleCube/index.ts
@@ -1,0 +1,30 @@
+import * as MXP from 'maxpower';
+import { Engine } from 'orengine';
+
+// サンプルコンポーネント。エンティティに立方体のメッシュを与える
+export class SampleCube extends MXP.Component {
+
+	constructor( params: MXP.ComponentParams ) {
+
+		super( params );
+
+		const engine = this.engine as Engine;
+
+		const geometry = new MXP.CubeGeometry( { width: 1, height: 1, depth: 1 } );
+
+		const material = new MXP.Material( {
+			uniforms: MXP.UniformsUtils.merge( engine.uniforms ),
+		} );
+
+		this.entity.addComponent( MXP.Mesh, { geometry, material } );
+
+	}
+
+	public dispose(): void {
+
+		super.dispose();
+		this.entity.removeComponent( MXP.Mesh );
+
+	}
+
+}

--- a/scripts/init.ts
+++ b/scripts/init.ts
@@ -1,0 +1,178 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ensureProjectExists } from './projectTemplate';
+
+/*
+	利用側リポジトリのセットアップスクリプト。
+	submodule を追加した利用側リポジトリのルートで実行する:
+
+		npx tsx orengine/scripts/init.ts
+
+	project/（テンプレート）・tsconfig.json・package.json の scripts を生成する。
+	既存のファイル・エントリは上書きしない。
+*/
+
+const orengineRoot = path.resolve( fileURLToPath( import.meta.url ), '../..' );
+const consumerRoot = process.cwd();
+
+// 利用側リポジトリのルートで実行されているか検証し、submodule への相対パス（posix区切り）を返す
+const resolveOrenginePath = () => {
+
+	if ( consumerRoot === orengineRoot ) {
+
+		console.error( '[orengine] run this script from your repository root (not inside the OREngine submodule)' );
+		process.exit( 1 );
+
+	}
+
+	const rel = path.relative( consumerRoot, orengineRoot );
+
+	if ( rel.startsWith( '..' ) || path.isAbsolute( rel ) ) {
+
+		console.error( `[orengine] the OREngine submodule (${orengineRoot}) is not inside the current directory (${consumerRoot})` );
+		console.error( '[orengine] run this script from your repository root' );
+		process.exit( 1 );
+
+	}
+
+	return rel.split( path.sep ).join( '/' );
+
+};
+
+// project/ をテンプレートから生成する
+const setupProject = () => {
+
+	const projectDir = path.join( consumerRoot, 'project' );
+
+	if ( fs.existsSync( projectDir ) ) {
+
+		console.log( '[orengine] skip: project/ already exists' );
+		return;
+
+	}
+
+	ensureProjectExists( projectDir, path.basename( consumerRoot ) );
+	console.log( '[orengine] created: project/' );
+
+};
+
+// パスエイリアスを submodule に向けた tsconfig.json を生成する
+const setupTsconfig = ( orengine: string ) => {
+
+	const tsconfigPath = path.join( consumerRoot, 'tsconfig.json' );
+
+	if ( fs.existsSync( tsconfigPath ) ) {
+
+		console.log( '[orengine] skip: tsconfig.json already exists (add the path aliases yourself if needed)' );
+		return;
+
+	}
+
+	// compilerOptions は submodule 側 tsconfig.json と揃える（orengine のソースも型チェック対象に入るため）
+	const tsconfig = {
+		compilerOptions: {
+			target: 'ES2020',
+			useDefineForClassFields: true,
+			lib: [ 'ES2020', 'DOM', 'DOM.Iterable', 'ES2021' ],
+			module: 'ESNext',
+			skipLibCheck: true,
+			moduleResolution: 'bundler',
+			allowImportingTsExtensions: true,
+			resolveJsonModule: true,
+			isolatedModules: true,
+			noEmit: true,
+			jsx: 'react-jsx',
+			strict: true,
+			baseUrl: '.',
+			typeRoots: [ `./${orengine}/node_modules`, `./${orengine}/node_modules/@types` ],
+			types: [ '@webgpu/types', 'node', 'dom-mediacapture-transform', 'dom-webcodecs' ],
+			paths: {
+				'basepower': [ `./${orengine}/packages/basepower` ],
+				'mathpower': [ `./${orengine}/packages/mathpower` ],
+				'glpower': [ `./${orengine}/packages/glpower` ],
+				'maxpower': [ `./${orengine}/packages/maxpower/webgl` ],
+				'maxpower/webgpu': [ `./${orengine}/packages/maxpower/webgpu` ],
+				'orengine': [ `./${orengine}/packages/orengine/index.ts` ],
+				'orengine/*': [ `./${orengine}/packages/orengine/*` ],
+				'@or-renderer': [ `./${orengine}/packages/maxpower/webgl/index.ts` ],
+				'@or-scene': [ './project/scene.json' ],
+				'@or-editor': [ './project/editor.json' ],
+				'@or-resources/*': [ './project/Resources/*' ],
+			},
+		},
+		// global.d.ts がシェーダーファイル import や vite/client の型を提供する
+		include: [ 'project', `${orengine}/global.d.ts` ],
+	};
+
+	fs.writeFileSync( tsconfigPath, JSON.stringify( tsconfig, null, 2 ) + '\n' );
+	console.log( '[orengine] created: tsconfig.json' );
+
+};
+
+// package.json に dev / player:build / editor:build の scripts と tsx を追加する
+const setupPackageJson = ( orengine: string ) => {
+
+	const pkgPath = path.join( consumerRoot, 'package.json' );
+
+	const pkg = fs.existsSync( pkgPath )
+		? JSON.parse( fs.readFileSync( pkgPath, 'utf-8' ) )
+		: { name: path.basename( consumerRoot ), private: true };
+
+	const scripts: Record<string, string> = {
+		'dev': `tsx ${orengine}/scripts/run.ts dev --project project`,
+		'player:build': `tsx ${orengine}/scripts/run.ts player:build --project project`,
+		'editor:build': `tsx ${orengine}/scripts/run.ts editor:build --project project`,
+	};
+
+	pkg.scripts = pkg.scripts ?? {};
+
+	for ( const [ name, cmd ] of Object.entries( scripts ) ) {
+
+		if ( pkg.scripts[ name ] !== undefined && pkg.scripts[ name ] !== cmd ) {
+
+			console.log( `[orengine] skip: scripts.${name} already exists in package.json` );
+			continue;
+
+		}
+
+		pkg.scripts[ name ] = cmd;
+
+	}
+
+	// 実行に必要なのは tsx だけ（依存パッケージはすべて submodule 側が持つ）
+	const hasTsx = pkg.dependencies?.tsx !== undefined || pkg.devDependencies?.tsx !== undefined;
+
+	if ( ! hasTsx ) {
+
+		pkg.devDependencies = { ...pkg.devDependencies, tsx: '^4.19.0' };
+
+	}
+
+	fs.writeFileSync( pkgPath, JSON.stringify( pkg, null, 2 ) + '\n' );
+	console.log( '[orengine] updated: package.json' );
+
+};
+
+/*-------------------------------
+	実行
+-------------------------------*/
+
+const orengine = resolveOrenginePath();
+
+setupProject();
+setupTsconfig( orengine );
+setupPackageJson( orengine );
+
+console.log( '' );
+console.log( '[orengine] setup complete. next steps:' );
+
+if ( ! fs.existsSync( path.join( orengineRoot, 'node_modules' ) ) ) {
+
+	console.log( `  (cd ${orengine} && npm install)` );
+
+}
+
+console.log( '  npm install' );
+console.log( '  npm run dev' );

--- a/scripts/projectTemplate.ts
+++ b/scripts/projectTemplate.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const templateDir = path.resolve( fileURLToPath( import.meta.url ), '../../host/template/project' );
+
+// テンプレートを再帰コピーしつつ {{KEY}} 形式のプレースホルダを置換する
+const copyDir = ( src: string, dst: string, replacements: Record<string, string> ) => {
+
+	fs.mkdirSync( dst, { recursive: true } );
+
+	for ( const entry of fs.readdirSync( src, { withFileTypes: true } ) ) {
+
+		const s = path.join( src, entry.name );
+		const d = path.join( dst, entry.name );
+
+		if ( entry.isDirectory() ) {
+
+			copyDir( s, d, replacements );
+
+		} else {
+
+			let content = fs.readFileSync( s, 'utf-8' );
+			for ( const [ k, v ] of Object.entries( replacements ) ) {
+
+				content = content.split( `{{${k}}}` ).join( v );
+
+			}
+			fs.writeFileSync( d, content );
+
+		}
+
+	}
+
+};
+
+// プロジェクトディレクトリが無ければテンプレートから生成する
+export const ensureProjectExists = ( projectDir: string, projectName: string ) => {
+
+	if ( fs.existsSync( projectDir ) ) return;
+
+	console.log( `[orengine] creating new project from template: ${projectName}` );
+	copyDir( templateDir, projectDir, { PROJECT_NAME: projectName } );
+
+};

--- a/scripts/run.ts
+++ b/scripts/run.ts
@@ -1,17 +1,34 @@
-import { execFileSync } from 'node:child_process';
-import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { ensureProjectExists } from './projectTemplate';
+
 const repoRoot = path.resolve( fileURLToPath( import.meta.url ), '../..' );
-const templateDir = path.join( repoRoot, 'host/template/project' );
 
 /*-------------------------------
 	設定解決
 -------------------------------*/
 
-// ORENGINE_PROJECT からアクティブプロジェクトを決める
+// --project（cwd 基準。利用側リポジトリからの実行用）または ORENGINE_PROJECT からアクティブプロジェクトを決める
 const resolveProject = () => {
+
+	const flagIndex = process.argv.indexOf( '--project' );
+
+	if ( flagIndex !== - 1 ) {
+
+		const name = process.argv[ flagIndex + 1 ];
+
+		if ( ! name ) {
+
+			throw new Error( '--project requires a path' );
+
+		}
+
+		const projectDir = path.resolve( process.cwd(), name );
+
+		return { projectName: path.basename( projectDir ), projectDir };
+
+	}
 
 	const name = process.env.ORENGINE_PROJECT || 'demo-webgl';
 
@@ -33,48 +50,6 @@ const resolveRenderer = () => {
 	}
 
 	return name;
-
-};
-
-/*-------------------------------
-	雛形生成（プロジェクトが無ければテンプレートからコピー）
--------------------------------*/
-
-const copyDir = ( src: string, dst: string, replacements: Record<string, string> ) => {
-
-	fs.mkdirSync( dst, { recursive: true } );
-
-	for ( const entry of fs.readdirSync( src, { withFileTypes: true } ) ) {
-
-		const s = path.join( src, entry.name );
-		const d = path.join( dst, entry.name );
-
-		if ( entry.isDirectory() ) {
-
-			copyDir( s, d, replacements );
-
-		} else {
-
-			let content = fs.readFileSync( s, 'utf-8' );
-			for ( const [ k, v ] of Object.entries( replacements ) ) {
-
-				content = content.split( `{{${k}}}` ).join( v );
-
-			}
-			fs.writeFileSync( d, content );
-
-		}
-
-	}
-
-};
-
-const ensureProjectExists = ( projectDir: string, projectName: string ) => {
-
-	if ( fs.existsSync( projectDir ) ) return;
-
-	console.log( `[orengine] creating new project from template: ${projectName}` );
-	copyDir( templateDir, projectDir, { PROJECT_NAME: projectName } );
 
 };
 
@@ -109,11 +84,6 @@ if ( cmd === 'dev' ) {
 	console.log( `[orengine] renderer = ${renderer}` );
 
 	await runBuildPlayer( { projectDir, renderer } );
-
-	// playerバンドルを自己解凍html（64k配布形式）にパックする
-	const playerJs = path.join( projectDir, 'dist/player/index.js' );
-	const packedHtml = path.join( projectDir, 'dist/player/out.html' );
-	execFileSync( 'node', [ path.join( repoRoot, 'tools/compeko.js' ), playerJs, packedHtml ], { stdio: 'inherit' } );
 
 } else if ( cmd === 'editor:build' ) {
 


### PR DESCRIPTION
## 概要

submodule 利用側リポジトリのセットアップが「テンプレート手動コピー・run.mjs 自作・tsconfig 手書き」と煩雑だったため、スクリプト1発で完了するようにする。

## 変更内容

- **`scripts/init.ts` を新規追加** — 利用側リポジトリのルートで `npx tsx orengine/scripts/init.ts` を実行すると以下を生成する（既存ファイル・既存 scripts は上書きせずスキップ）
  - `project/` — テンプレートから生成
  - `tsconfig.json` — パスエイリアス・`global.d.ts` の include・本体相当の compilerOptions 済み
  - `package.json` — `dev` / `player:build` / `editor:build` の scripts と `tsx` の devDependency
- **`scripts/run.ts` に `--project <path>`（cwd 基準）を追加** — 生成された scripts はこれ経由で動く。テンプレート生成処理は `scripts/projectTemplate.ts` へ切り出して init と共有
- **compeko パックを `runBuildPlayer`（host/runner.ts）へ移動** — README には「自己解凍 HTML を出力」とあったが、実際のパック処理は `scripts/run.ts` にしかなく、API 直接利用ではパックされない乖離があったため解消
- **テンプレートに `SampleCube` コンポーネントを追加** — テンプレートに .ts が1つも無いと生成した tsconfig が TS18003（inputs なし）になるため。Geometry + Material + Mesh の最小参照実装を兼ねる
- **README の利用手順を書き直し** — 5ステップ → 「submodule add → orengine で npm install → init 実行 → npm install」

## 検証

利用側リポジトリを模擬して実走確認済み:

- init 実行 → 生成物3点を確認
- submodule の tsc 流用で `tsc --noEmit` → exit 0
- `npm run player:build` → `project/dist/player/out.html` 28,812 bytes（compeko パック込み）
- 本体側の回帰: `npm run player:build` → packed **40,019 bytes（既存ベースラインと一致）**
- `npm run typecheck` / `npm run lint` パス