### PR TITLE
バージョンを0.0.1に更新しリリース時のバージョン更新ルールを追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ OREngine 自体の開発エントリは `host/` に集約されている:
 - 対応ブランチは PR 経由でリリースブランチへマージする
 - 緊急修正のみ `hotfix/xxx` を `master` から切り、PR 経由で `master` へ直接マージする
 - リリースは、リリースブランチを PR 経由で `master` へマージして行う。リリース時は GitHub にリリースを作成する
+- リリース前に `package.json` の `version` をリリース番号に合わせて更新する（`npm version X.Y.Z --no-git-tag-version` で package-lock.json ごと更新し、PR 経由でリリースブランチへ入れる）
 - PR のマージはすべて merge commit で行う（squash / rebase はリポジトリ設定で無効）
 - バージョン番号はセマンティックバージョニングに従う。リリースブランチを切るのはユーザーだが、番号を提案するときは変更内容から major / minor / patch を判断する
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orengine",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orengine",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "dependencies": {
         "@rollup/plugin-terser": "^1.0.0",
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orengine",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "exports": {
     ".": "./packages/orengine/index.ts",


### PR DESCRIPTION
## 概要
- package.json / package-lock.json の version を 0.0.1 に更新
- CLAUDE.md のブランチ運用に「リリース前に package.json の version をリリース番号に合わせて更新する」ルールを追記

v0.0.1 リリースの事前準備。