### PR TITLE
ブランチ名変更（master→main）に合わせてworkflowとドキュメントの参照を更新する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # PR の品質ゲート。ruleset の required status checks に "check" として登録されており、
-# これが通らないと master / release/* へマージできない
+# これが通らないと main / release/* へマージできない
 name: ci
 
 on:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,13 +1,13 @@
-# master / release/* への push で GitHub Pages（gh-pages ブランチ）を更新する
+# main / release/* への push で GitHub Pages（gh-pages ブランチ）を更新する
 # 配置（いずれもミラー構成: ルート = エディタデモ（editor:build） / storybook/ = Storybook）:
-#   master     → サイトルート（pr-preview/ と release/ は他workflowと共存のため消さない）
+#   main     → サイトルート（pr-preview/ と release/ は他workflowと共存のため消さない）
 #   release/*  → release/<ブランチ名>/ 配下（ブランチ削除で cleanup ジョブが撤去する）
 name: deploy-pages
 
 on:
   push:
     branches:
-      - master
+      - main
       - release/**
   delete:
   workflow_dispatch:
@@ -34,7 +34,7 @@ jobs:
       - name: Determine deploy path
         id: vars
         run: |
-          if [ "${{ github.ref_name }}" = "master" ]; then
+          if [ "${{ github.ref_name }}" = "main" ]; then
             echo "DIR=" >> "$GITHUB_OUTPUT"
             echo "BASE=/OREngine/" >> "$GITHUB_OUTPUT"
           else
@@ -60,7 +60,7 @@ jobs:
           mv site/static.html site/index.html
           cp -r storybook-static site/storybook
           touch site/.nojekyll
-      - name: Deploy (master → site root)
+      - name: Deploy (main → site root)
         if: steps.vars.outputs.DIR == ''
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,12 +66,12 @@ OREngine 自体の開発エントリは `host/` に集約されている:
 - **必須**: コード変更後は `npm run typecheck` で型チェックを実行し、続けて `npm run lint --fix` でESLintエラーを自動修正する
 
 ### ブランチ運用
-- `master` からリリースブランチ `release/vX.Y.Z`（例: `release/v0.0.1`）を切る
-- `master` / リリースブランチへの直接コミットは禁止（branch protection でも強制）。作業はリリースブランチから対応ブランチ（`feature/xxx` 等）を切って行う
+- `main` からリリースブランチ `release/vX.Y.Z`（例: `release/v0.0.1`）を切る
+- `main` / リリースブランチへの直接コミットは禁止（branch protection でも強制）。作業はリリースブランチから対応ブランチ（`feature/xxx` 等）を切って行う
 - 作業開始時に現在のブランチが作業内容と乖離している場合（リリースブランチ上にいる場合も含む）は、最新のリリースブランチから新しく対応ブランチを切ってから作業する
 - 対応ブランチは PR 経由でリリースブランチへマージする
-- 緊急修正のみ `hotfix/xxx` を `master` から切り、PR 経由で `master` へ直接マージする
-- リリースは、リリースブランチを PR 経由で `master` へマージして行う。リリース時は GitHub にリリースを作成する
+- 緊急修正のみ `hotfix/xxx` を `main` から切り、PR 経由で `main` へ直接マージする
+- リリースは、リリースブランチを PR 経由で `main` へマージして行う。リリース時は GitHub にリリースを作成する
 - リリース前に `package.json` の `version` をリリース番号に合わせて更新する（`npm version X.Y.Z --no-git-tag-version` で package-lock.json ごと更新し、PR 経由でリリースブランチへ入れる）
 - PR のマージはすべて merge commit で行う（squash / rebase はリポジトリ設定で無効）
 - バージョン番号はセマンティックバージョニングに従う。リリースブランチを切るのはユーザーだが、番号を提案するときは変更内容から major / minor / patch を判断する
@@ -95,7 +95,7 @@ npm run typecheck    # TypeScript型チェック + 全scssのコンパイル検�
 - VRT（見た目のスクリーンショット比較テスト）は `tests/vrt/`（Playwright）。見た目に影響する変更をしたら `npm run vrt` で確認し、意図した変更なら `npm run vrt:update` で基準画像を更新する
 
 ### CI / GitHub Pages
-- `.github/workflows/deploy-pages.yml` — master / release/* への push でエディタデモと Storybook を gh-pages ブランチへデプロイ（ルート = エディタデモ、`/storybook/`）
+- `.github/workflows/deploy-pages.yml` — main / release/* への push でエディタデモと Storybook を gh-pages ブランチへデプロイ（ルート = エディタデモ、`/storybook/`）
 - `.github/workflows/pr-preview.yml` — PR ごとに `/pr-preview/pr-N/` へプレビューをデプロイし、リンクを PR にコメントする
 - サブパス配信は `BASE_PATH` 環境変数で行う
 


### PR DESCRIPTION
リモートブランチのリネーム（master→main）に伴い、workflowのトリガー・デプロイ条件とCLAUDE.mdのブランチ運用記述の参照を更新する。

- deploy-pages.yml: トリガーブランチとサイトルートへのデプロイ条件を main に変更
- ci.yml: コメント内のブランチ名を更新
- CLAUDE.md: ブランチ運用・CI/Pages の記述を更新